### PR TITLE
[+]如果在拖动过程中,调用refill会因为同一帧处理的缘故,造成到位后还在滚动的bug.

### DIFF
--- a/Assets/Scripts/LoopScrollRect.cs
+++ b/Assets/Scripts/LoopScrollRect.cs
@@ -18,6 +18,8 @@ namespace UnityEngine.UI
         [Tooltip("Total count, negative means INFINITE mode")]
         public int totalCount;
 
+        private bool stopMovementFlag = false;
+
         [HideInInspector]
         [NonSerialized]
         public LoopScrollDataSource dataSource = LoopScrollSendIndexSource.Instance;
@@ -740,6 +742,9 @@ namespace UnityEngine.UI
 
         public virtual void StopMovement()
         {
+            if (m_Velocity != Vector2.one)
+                m_stopMovementFlag = true;
+
             m_Velocity = Vector2.zero;
         }
 
@@ -859,6 +864,12 @@ namespace UnityEngine.UI
         {
             if (!m_Content)
                 return;
+
+            if (m_stopMovementFlag)
+            {
+                m_stopMovementFlag = false;
+                return;
+            }
 
             EnsureLayoutHasRebuilt();
             UpdateScrollbarVisibility();


### PR DESCRIPTION
### 具体测试流程:

1. 先调用refill填充数据,尽量大500~1000
2. 调用refill+offset参数 然后做到类似跳转到某一个index的情况,例如跳转到999
3. 在界面上添加一个测试按钮用来调用第二步的函数
4. 拖动界面,同时点击按钮
5. 最终的情况会出现我已经refill到指定index,但是还是会滚动.
6. 我在代码里面处理了一下,让调用stop后再判断是否之前有值,有的话等待一帧.