### PR TITLE
fix issue: when not full of line items in the grid. the grid will show error.

### DIFF
--- a/Assets/Scripts/LoopHorizontalScrollRect.cs
+++ b/Assets/Scripts/LoopHorizontalScrollRect.cs
@@ -61,6 +61,10 @@ namespace UnityEngine.UI
                     offsetCount = Mathf.FloorToInt((float)(itemTypeStart) / contentConstraintCount);
                 }
                 itemTypeStart -= offsetCount * contentConstraintCount;
+				if (itemTypeStart < 0)
+                {
+                    itemTypeStart = 0;
+                }
                 itemTypeEnd = itemTypeStart;
 
                 float offset = offsetCount * (elementSize + contentSpacing);
@@ -91,6 +95,10 @@ namespace UnityEngine.UI
                     offsetCount = Mathf.FloorToInt((float)(maxItemTypeStart - itemTypeStart) / contentConstraintCount);
                 }
                 itemTypeStart += offsetCount * contentConstraintCount;
+				if (itemTypeStart < 0)
+                {
+                    itemTypeStart = 0;
+                }
                 itemTypeEnd = itemTypeStart;
 
                 float offset = offsetCount * (elementSize + contentSpacing);

--- a/Assets/Scripts/LoopHorizontalScrollRect.cs
+++ b/Assets/Scripts/LoopHorizontalScrollRect.cs
@@ -61,7 +61,7 @@ namespace UnityEngine.UI
                     offsetCount = Mathf.FloorToInt((float)(itemTypeStart) / contentConstraintCount);
                 }
                 itemTypeStart -= offsetCount * contentConstraintCount;
-				if (itemTypeStart < 0)
+                if (itemTypeStart < 0)
                 {
                     itemTypeStart = 0;
                 }
@@ -95,7 +95,7 @@ namespace UnityEngine.UI
                     offsetCount = Mathf.FloorToInt((float)(maxItemTypeStart - itemTypeStart) / contentConstraintCount);
                 }
                 itemTypeStart += offsetCount * contentConstraintCount;
-				if (itemTypeStart < 0)
+                if (itemTypeStart < 0)
                 {
                     itemTypeStart = 0;
                 }

--- a/Assets/Scripts/LoopVerticalScrollRect.cs
+++ b/Assets/Scripts/LoopVerticalScrollRect.cs
@@ -67,6 +67,10 @@ namespace UnityEngine.UI
                     offsetCount = Mathf.FloorToInt((float)(maxItemTypeStart - itemTypeStart) / contentConstraintCount);
                 }
                 itemTypeStart += offsetCount * contentConstraintCount;
+				if (itemTypeStart < 0)
+                {
+                    itemTypeStart = 0;
+                }
                 itemTypeEnd = itemTypeStart;
 
                 float offset = offsetCount * (elementSize + contentSpacing);
@@ -90,6 +94,10 @@ namespace UnityEngine.UI
                     offsetCount = Mathf.FloorToInt((float)(itemTypeStart) / contentConstraintCount);
                 }
                 itemTypeStart -= offsetCount * contentConstraintCount;
+				if (itemTypeStart < 0)
+                {
+                    itemTypeStart = 0;
+                }
                 itemTypeEnd = itemTypeStart;
 
                 float offset = offsetCount * (elementSize + contentSpacing);

--- a/Assets/Scripts/LoopVerticalScrollRect.cs
+++ b/Assets/Scripts/LoopVerticalScrollRect.cs
@@ -67,7 +67,7 @@ namespace UnityEngine.UI
                     offsetCount = Mathf.FloorToInt((float)(maxItemTypeStart - itemTypeStart) / contentConstraintCount);
                 }
                 itemTypeStart += offsetCount * contentConstraintCount;
-				if (itemTypeStart < 0)
+                if (itemTypeStart < 0)
                 {
                     itemTypeStart = 0;
                 }
@@ -94,7 +94,7 @@ namespace UnityEngine.UI
                     offsetCount = Mathf.FloorToInt((float)(itemTypeStart) / contentConstraintCount);
                 }
                 itemTypeStart -= offsetCount * contentConstraintCount;
-				if (itemTypeStart < 0)
+                if (itemTypeStart < 0)
                 {
                     itemTypeStart = 0;
                 }


### PR DESCRIPTION
![1](https://user-images.githubusercontent.com/7285186/101768362-6ede8080-3b20-11eb-8fea-772b4c8d0979.png)
![2](https://user-images.githubusercontent.com/7285186/101768379-72720780-3b20-11eb-9641-c407c589e41f.png)
![3](https://user-images.githubusercontent.com/7285186/101768355-6d14bd00-3b20-11eb-9487-f18cab0ded9a.png)


